### PR TITLE
Do not block on first eval when creating the panel

### DIFF
--- a/src/panel.ts
+++ b/src/panel.ts
@@ -68,9 +68,11 @@ export class PythonBytecodePanel extends Panel {
   public async setup(): Promise<any> {
     await this._session.initialize();
     await this._session.ready;
-    await this._getFileContent();
-    await this._changeTheme();
     await this._setupListeners();
+
+    // do not block on first request
+    this._getFileContent();
+    this._changeTheme();
   }
 
   protected onCloseRequest(msg: Message): void {


### PR DESCRIPTION
Fixes a slight delay that would prevent the panel to be displayed before receiving the first response from the kernel.