### PR TITLE
Name the console session using the path name

### DIFF
--- a/src/panel.ts
+++ b/src/panel.ts
@@ -48,6 +48,8 @@ export class PythonBytecodePanel extends Panel {
 
     const { kernelLanguagePreference, kernelAutoStart } = userSettings;
 
+    name = name || widget.context.contentsModel.name;
+
     this._session = new ClientSession({
       manager: serviceManager.sessions,
       path,


### PR DESCRIPTION
To follow the same behavior as when opening a console for a file.

**Before**

![image](https://user-images.githubusercontent.com/591645/47380018-c7fab880-d6fc-11e8-9947-69ad2a52abdc.png)


**After**

![image](https://user-images.githubusercontent.com/591645/47379910-7d793c00-d6fc-11e8-9e8b-3adbe8eac4e4.png)
