### PR TITLE
Restore Bytecode panel on refresh

### DIFF
--- a/src/panel.ts
+++ b/src/panel.ts
@@ -27,7 +27,7 @@ export class PythonBytecodePanel extends Panel {
     super();
 
     const count = Private.count++;
-    this.id = `PythonBytecodePanel-${count}`;
+    this.id = `${PythonBytecodePanel.NAMESPACE}-${count}`;
     this.title.label = 'Python Bytecode';
     this.title.closable = true;
     this.title.icon = ICON_CLASS;
@@ -161,6 +161,8 @@ export class PythonBytecodePanel extends Panel {
 }
 
 export namespace PythonBytecodePanel {
+  export const NAMESPACE = 'PythonBytecodePanel';
+
   export interface IOptions {
     /**
      * The service manager used to get a list


### PR DESCRIPTION
Fixes #6.

Use `ILayoutRestorer` to track the panel and restore it on refresh.

![restorer](https://user-images.githubusercontent.com/591645/47826243-f882c800-dd76-11e8-8012-42e3de777d53.gif)
