### PR TITLE
Add an option to always start new kernels

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -10,6 +10,12 @@
       "default": "Python 3",
       "type": "string"
     },
+    "startNewKernel": {
+      "title": "Start a new Kernel",
+      "description": "Whether to always start a new kernel or not",
+      "default": false,
+      "type": "boolean"
+    },
     "kernelAutoStart": {
       "title": "Autostart Kernel",
       "description": "Whether the kernel should start automatically",

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -93,7 +93,7 @@ export class PythonBytecodePanel extends Panel {
     this.title.label = `${this._session.kernelDisplayName} Bytecode`;
     this.title.caption = this._session.name;
 
-    this._session.setName(
+    await this._session.setName(
       `${this._session.name} - ${this._session.kernelDisplayName}`,
     );
 

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -16,7 +16,7 @@ import { DocumentRegistry } from '@jupyterlab/docregistry';
 
 import { ServiceManager } from '@jupyterlab/services';
 
-import { JSONObject } from '@phosphor/coreutils';
+import { JSONObject, UUID } from '@phosphor/coreutils';
 
 import { Message } from '@phosphor/messaging';
 
@@ -56,13 +56,17 @@ export class PythonBytecodePanel extends Panel {
     this._themeManager = themeManager;
     this._selections = selections;
 
-    const { kernelLanguagePreference, kernelAutoStart } = userSettings;
+    const {
+      kernelLanguagePreference,
+      kernelAutoStart,
+      startNewKernel,
+    } = userSettings;
 
     name = name || widget.context.contentsModel.name;
 
     this._session = new ClientSession({
       manager: serviceManager.sessions,
-      path,
+      path: startNewKernel ? UUID.uuid4() : path,
       name: name || `Python Bytecode`,
       type: 'console',
       kernelPreference: {
@@ -88,6 +92,10 @@ export class PythonBytecodePanel extends Panel {
 
     this.title.label = `${this._session.kernelDisplayName} Bytecode`;
     this.title.caption = this._session.name;
+
+    this._session.setName(
+      `${this._session.name} - ${this._session.kernelDisplayName}`,
+    );
 
     await this._setupListeners();
 


### PR DESCRIPTION
In the Advanced Settings Editor, to set whether to always start a new kernel for the same document or not:

```json
{
  "startNewKernel": true
}
```